### PR TITLE
implemented set asset activity command

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -60,7 +60,7 @@ async function revertStaledClaimsLoop(assetManagementService: AssetManagementSer
     const assetManagementService = await AssetManagementServiceDsl.loadFromEnv({ database, blockfrost, identityService, secureSigningService })
     const accountService = await AccountServiceDsl.loadFromEnv({ identityService, assetManagementService, governanceService,wellKnownPolicies })
     const idleQuestsService = await IdleQuestsServiceDsl.loadFromEnv({ randomSeed, calendar, database, evenstatsService, assetManagementService, metadataRegistry, questsRegistry, wellKnownPolicies })
-    const kiliaBotService = await KiliaBotServiceDsl.loadFromEnv({ database, evenstatsService, identityService, governanceService })
+    const kiliaBotService = await KiliaBotServiceDsl.loadFromEnv({ database, evenstatsService, identityService, governanceService, idleQuestsService })
     
     // Soon to be deprecated
     //await loadQuestModuleModels(database)

--- a/backend/src/service-idle-quests/service-spec.ts
+++ b/backend/src/service-idle-quests/service-spec.ts
@@ -35,6 +35,8 @@ export interface IdleQuestsService {
     getInventory(userId: string, logger?: LoggingContext): Promise<GetInventoryResult>
 
     grantTestInventory(userId: string, logger?: LoggingContext): Promise<GetInventoryResult>
+    
+    setSingleAssetActivity(userId: string, assetRef: string, activity: boolean, logger?: LoggingContext): Promise<{status: "ok"} | {status: "failed", reason: string}>
 
     setInnState(userId: string, name?: string, objectLocations?: vm.ObjectsLocations, logger?: LoggingContext): Promise<void>
 }

--- a/backend/src/service-idle-quests/service.ts
+++ b/backend/src/service-idle-quests/service.ts
@@ -396,4 +396,8 @@ export class IdleQuestsServiceDsl implements IdleQuestsService {
         if (!name && !objectLocations) return
         await SectorState.setPlayerInnState(userId, name, objectLocations)
     }
+
+    async setSingleAssetActivity(userId: string, assetRef: string, activity: boolean, logger?: LoggingContext | undefined): Promise<{status: "ok"} | {status: "failed", reason: string}> {
+        return this.characterState.updateSingleAssetActivityStatus(userId, assetRef, activity)
+    }
 }


### PR DESCRIPTION
Title: Implement set-asset-activity command

Description:

This PR addresses issue #68 

Adding a new command set-asset-activity, which allows setting the activity status of a specific asset for a user. The command takes three arguments: userId, assetRef, and activity. activity should be either 'true' or 'false'.